### PR TITLE
Fix algorithm bugs & setup comparsion between two algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,5 @@ ENV/
 
 kubesv/tests/output
 kano_py/data/
+data/
 .DS_Store

--- a/kano_py/kano/algorithm.py
+++ b/kano_py/kano/algorithm.py
@@ -30,7 +30,7 @@ def user_crosscheck(
         label: str) -> List[int]:
     """
     User cross. 
-    A container can reach other user’s container in the container network
+    A container can be reached from other user’s container in the container network
     """
     user_crosslist = []
     user_map = user_hashmap(containers, label)

--- a/kano_py/kano/algorithm.py
+++ b/kano_py/kano/algorithm.py
@@ -1,4 +1,4 @@
-from kano.model import *
+from .model import *
 
 
 def all_reachable(matrix: ReachabilityMatrix) -> List[int]:
@@ -67,12 +67,10 @@ def policy_shadow(matrix: ReachabilityMatrix, policies: List[Policy], containers
     pols = []
     for i, container in enumerate(containers):
         i_select = container.select_policies
-        for j in i_select:
-            for k in i_select:
+        for j, pj in enumerate(i_select):
+            for k, pk in enumerate(i_select):
                 if j == k:
                     continue
-                pj = policies[j]
-                pk = policies[k]
                 j_allow = pj.working_allow_set
                 k_allow = pk.working_allow_set
                 if ((j_allow & k_allow) ^ k_allow).count() == 0:

--- a/kano_py/kano/parser.py
+++ b/kano_py/kano/parser.py
@@ -1,4 +1,4 @@
-from kano.model import *
+from .model import *
 
 from yaml import load, dump
 import os
@@ -45,6 +45,7 @@ class ConfigParser:
                             self.create_object(data)
             except:
                 print("Error opening or reading directory")
+                raise 
 
         return self.containers, self.policies
 
@@ -77,9 +78,13 @@ class ConfigParser:
 
         elif data['kind'] == 'Pod':
             labels = data['metadata']['labels']
+            # XXX: use pod name as container name since they are the label owners
+            """
             for container in data['spec']['containers']:
                 new_container = Container(container['name'], labels)
-                self.containers.append(new_container)
+            """
+            new_container = Container(data['metadata']['name'], labels)
+            self.containers.append(new_container)
 
 
     def print_all(self):

--- a/kano_py/tests/generate.py
+++ b/kano_py/tests/generate.py
@@ -1,6 +1,8 @@
 import os
 import random
-from kano.model import *
+import yaml
+from collections import OrderedDict
+from ..kano.model import *
 
 class ConfigFiles:
     def __init__(self, podN=100,nsN=5,policyN=50,podLL=5,nsLL=5,keyL=5,valueL=10,userL=5,selectedLL=3,allowNSLL=3,allowpodLL=3):
@@ -16,10 +18,10 @@ class ConfigFiles:
         self.selectedLL = selectedLL
         self.allowNSLL = allowNSLL
         self.allowpodLL = allowpodLL
-        self.generatePods()
         self.directory = "data/policy"
         if not os.path.exists("data"):
             os.makedirs("data")
+        self.generatePods()
         # self.generateNamespaces()
 
     def generatePods(self):
@@ -33,6 +35,18 @@ class ConfigFiles:
                 labels[random.choice(self.keys)] = random.choice(self.values)
             pod = Container(podName, labels)
             containers.append(pod)
+
+            y_pod = {}
+            y_pod['apiVersion'] = 'v1'
+            y_pod['kind'] = 'Pod'
+            y_pod['metadata'] = {
+                'name': podName,
+                'namespace': 'default',
+                'labels': labels
+            }
+            with open("data/pod{}.yml".format(i), 'w+') as f:
+                f.write(yaml.dump(y_pod, default_flow_style=False, sort_keys=False))
+
         self.containers = containers
         return
 
@@ -94,3 +108,8 @@ class ConfigFiles:
 
     def getPods(self):
         return self.containers
+
+
+if __name__ == "__main__":
+    config = ConfigFiles()
+    config.generateConfigFiles()

--- a/kano_py/tests/test_basic.py
+++ b/kano_py/tests/test_basic.py
@@ -1,7 +1,7 @@
 from kano.model import ReachabilityMatrix
 from kano.algorithm import *
-from tests.context import sample
-from tests.generate import ConfigFiles
+from .context import sample
+from .generate import ConfigFiles
 from kano.parser import ConfigParser
 
 import unittest

--- a/kubesv/kubesv/model.py
+++ b/kubesv/kubesv/model.py
@@ -253,7 +253,7 @@ class PolicyPeerAdapter:
     @property
     def ip_block(self) -> Optional[Tuple[IPAddress, List[IPAddress]]]:
         """
-        XXX: for current version, may ignore this selector
+        TODO: for current version, may ignore this selector
         IPBlock defines policy on a particular IPBlock. 
         If this field is set then neither of the other fields can be.
         """
@@ -471,7 +471,7 @@ class PolicyAdapter:
 
         # if ingress is empty, this NetworkPolicy does not allow any traffic
         # no ingress_allow_by_pol(Pod, idx) defined
-        if self.egress_rules is None:
+        if self.ingress_rules is None:
             return
 
         # each ingress rule is independent (OR-chained)

--- a/kubesv/kubesv/postprocess.py
+++ b/kubesv/kubesv/postprocess.py
@@ -136,7 +136,7 @@ def all_reach_isolate(gi: GlobalInfo):
 
 def user_crosscheck(gi: GlobalInfo, l: str):
     """
-    A container can reach other user’s container in the container network
+    A container can be reached from other user’s container in the container network
     User is specified by the label. 
     Kano: All constainers should have that label.
     """
@@ -256,7 +256,7 @@ def policy_shadow(gi: GlobalInfo):
     return sat, parse_z3_result(answer)
 
 
-def policy_shadow(gi: GlobalInfo):
+def policy_conflict(gi: GlobalInfo):
     """
     The connections built by a policy are totally contradict the connections built by another    
     NOTE: this is a general version, not Kano's per pod version

--- a/kubesv/kubesv/postprocess.py
+++ b/kubesv/kubesv/postprocess.py
@@ -1,0 +1,315 @@
+"""
+Post processing some z3 results to implement similar results as Kano.
+Kano's problems: 
+    1. namespace support (namespace is separated objects from pods/containers), and namespaceSelector requires these entities
+    2. self-ingress traffic & not selected traffic (serious)
+    3. fail to handle empty selectors => which means selecting all instead of none
+    4. Kano only consider edges, not transistive paths
+    5. ad-hoc algorithm, NoD can express
+"""
+from io import UnsupportedOperation
+from z3 import *
+from typing import *
+from typing_extensions import *
+from bitarray import bitarray
+from .constraint import GlobalInfo, get_answer
+
+
+def parse_z3_var_assignment(assign):
+    idx = get_var_index(assign.arg(0))
+    num = assign.arg(1).as_long()
+    return idx, num
+
+
+def parse_z3_and_var(assigns):
+    results = []
+    for i in range(assigns.num_args()):
+        assign = assigns.arg(i)
+        results.append(parse_z3_var_assignment(assign))
+    return results
+
+
+def parse_z3_or_and(answer: BoolRef) -> Set[Tuple[int, ...]]:
+    # assume the answer is Or(And(Var0, Var1, ...), ...)
+    all_answer = None
+    
+    if is_eq(answer):
+        return parse_z3_var_assignment(answer)
+
+    if is_and(answer):
+        all_answer = [-1 for _ in range(answer.num_args())]
+        for i in range(answer.num_args()):
+            assign = answer.arg(i)
+            idx, num = parse_z3_or_and(assign)
+            all_answer[idx] = num
+    elif is_or(answer):
+        all_answer = set()
+        for i in range(answer.num_args()):
+            assigns = answer.arg(i)
+            result = parse_z3_or_and(assigns)
+            if isinstance(result, tuple):
+                all_answer.add(result[1])
+            else:
+                all_answer.add(tuple(result))
+
+    return all_answer
+
+
+def parse_z3_result(answer: BoolRef):
+    result = parse_z3_or_and(answer)
+    if isinstance(result, list):
+        return {tuple(result)}
+    elif isinstance(result, tuple):
+        return {result[1]}
+    return result
+
+
+def get_z3_bitarray(answer: BoolRef, n_container: int, is_ingress=True) -> List[bitarray]:
+    # assume the answer is Or(And(Var0, Var1, ...), ...)
+    all_answer = [bitarray('0' * n_container) for _ in range(n_container)]
+    pairs = parse_z3_result(answer)
+    if pairs is None:
+        return all_answer
+    for src, dst in pairs:
+        if is_ingress:
+            all_answer[src][dst] = True
+        else:
+            all_answer[dst][src] = True
+    return all_answer
+
+
+def all_reachable(matrix: List[bitarray]) -> List[int]:
+    all_reachables = []
+    for i in range(len(matrix)):
+        is_all_reachable = True
+        for j in range(len(matrix)):
+            if matrix[j][i] != True:
+                is_all_reachable = False
+                break
+        if is_all_reachable:
+            all_reachables.append(i)
+    return all_reachables
+
+
+def all_isolated(matrix: List[bitarray]) -> List[int]:
+    all_isolated = []
+    for i in range(len(matrix)):
+        is_all_isolated = True
+        for j in range(len(matrix)):
+            if matrix[j][i] != False:
+                is_all_isolated = False
+                break
+        if is_all_isolated:
+            all_isolated.append(i)
+    return all_isolated
+
+
+def get_all_pairs(gi: GlobalInfo, rel: str):
+    rel = gi.get_relation_core(rel)
+
+    src = gi.declare_var('src_pair', gi.pod_sort)
+    dst = gi.declare_var('dst_pair', gi.pod_sort)
+
+    fact = [rel(src, dst)]
+    sat, answer = get_answer(gi.fp, fact)
+    if sat == z3.unsat:
+        return sat, set()
+    
+    return sat, parse_z3_result(answer)    
+
+
+def get_all_edges(gi: GlobalInfo):
+    return get_all_pairs(gi, "edge") 
+
+
+def all_reach_isolate(gi: GlobalInfo):
+    rel = gi.get_relation_core("edge")
+
+    src = gi.declare_var('src_edge', gi.pod_sort)
+    dst = gi.declare_var('dst_edge', gi.pod_sort)
+
+    fact = [rel(src, dst)]
+    sat, answer = get_answer(gi.fp, fact)
+    matrix = get_z3_bitarray(answer, len(gi.pods))
+    return all_reachable(matrix), all_isolated(matrix)
+
+
+def user_crosscheck(gi: GlobalInfo, l: str):
+    """
+    A container can reach other user’s container in the container network
+    User is specified by the label. 
+    Kano: All constainers should have that label.
+    """
+    label = gi.get_relation(l)
+    is_pod = gi.get_relation_core("is_pod")
+    edge = gi.get_relation_core("edge")
+
+    user_violation = Function('user_violation_{}'.format(label), gi.pod_sort, BoolSort())
+    gi.register_relation("user_violation_{}".format(label), user_violation, is_core=True)
+
+    sel = gi.declare_var('sel_{}'.format(label), gi.pod_sort)
+    random = gi.declare_var('random_{}'.format(label), gi.pod_sort)
+    lv0 = gi.declare_var('label_value_0_{}'.format(label), gi.lv_sort)
+    lv1 = gi.declare_var('label_value_1_{}'.format(label), gi.lv_sort)
+
+    gi.add_rule(user_violation(sel), [
+        is_pod(sel),
+        is_pod(random),
+        edge(random, sel),
+        label(random, lv0),
+        label(sel, lv1),
+        lv0 != lv1
+    ])
+
+    fact = [user_violation(sel)]
+    sat, answer = get_answer(gi.fp, fact)
+    if sat == z3.unsat:
+        return sat, []
+    
+    return sat, parse_z3_result(answer)
+
+
+def system_isolation(gi: GlobalInfo, idx: int):
+    """
+    A container is isolated with certain container, usually the kube-system container
+    System pod is specified by idx
+    Kano: only consider egress edge, not path
+    """
+    is_pod = gi.get_relation_core("is_pod")
+    edge = gi.get_relation_core("edge")
+    pod_idx = gi.pod_value(idx)
+
+    system_isolation = Function('system_isolation_{}'.format(idx), gi.pod_sort, BoolSort())
+    gi.register_relation("system_isolation_{}".format(idx), system_isolation, is_core=True)
+
+    sel = gi.declare_var('system_iso_sel_{}'.format(idx), gi.pod_sort)
+
+    gi.add_rule(system_isolation(sel), [
+        is_pod(sel),
+        Not(edge(sel, pod_idx))
+    ])
+
+    fact = [system_isolation(sel)]
+    sat, answer = get_answer(gi.fp, fact)
+    if sat == z3.unsat:
+        return []
+    
+    return sat, parse_z3_result(answer)
+
+
+def policy_shadow(gi: GlobalInfo):
+    """
+    The connections built by a policy are completely covered by another policy, then this policy may be redundant
+    NOTE: this is a general version, not Kano's per pod version
+    """
+    is_pod = gi.get_relation_core("is_pod")
+    is_pol = gi.get_relation_core("is_pol")
+    selected_by_pol = gi.get_relation_core("selected_by_pol")
+    ingress_allow_by_pol = gi.get_relation_core("ingress_allow_by_pol")
+    egress_allow_by_pol = gi.get_relation_core("egress_allow_by_pol")
+
+    policy_shadow = Function('policy_shadow', gi.pol_sort, gi.pol_sort, BoolSort())
+    gi.register_relation("policy_shadow", policy_shadow, is_core=True)
+    policy_unshadow = Function('policy_unshadow', gi.pol_sort, gi.pol_sort, BoolSort())
+    gi.register_relation("policy_unshadow", policy_unshadow, is_core=True)
+
+
+    p0 = gi.declare_var('policy_shadow_inner', gi.pol_sort)
+    p1 = gi.declare_var('policy_shadow_outer', gi.pol_sort)
+
+    select = gi.declare_var('policy_shadow_select', gi.pod_sort)
+
+    gi.add_rule(policy_unshadow(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        is_pod(select),
+        selected_by_pol(select, p0),
+        Not(selected_by_pol(select, p1))
+    ])
+    gi.add_rule(policy_unshadow(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        is_pod(select),
+        ingress_allow_by_pol(select, p0),
+        Not(ingress_allow_by_pol(select, p1))
+    ])
+    gi.add_rule(policy_unshadow(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        is_pod(select),
+        egress_allow_by_pol(select, p0),
+        Not(egress_allow_by_pol(select, p1))
+    ])
+
+    gi.add_rule(policy_shadow(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        p0 != p1,
+        Not(policy_unshadow(p0, p1))        
+    ])
+
+    fact = [policy_shadow(p0, p1)]
+    sat, answer = get_answer(gi.fp, fact)
+    if sat == z3.unsat:
+        return []
+    
+    return sat, parse_z3_result(answer)
+
+
+def policy_shadow(gi: GlobalInfo):
+    """
+    The connections built by a policy are totally contradict the connections built by another    
+    NOTE: this is a general version, not Kano's per pod version
+    """
+    is_pod = gi.get_relation_core("is_pod")
+    is_pol = gi.get_relation_core("is_pol")
+    selected_by_pol = gi.get_relation_core("selected_by_pol")
+    ingress_allow_by_pol = gi.get_relation_core("ingress_allow_by_pol")
+    egress_allow_by_pol = gi.get_relation_core("egress_allow_by_pol")
+
+    policy_conflict = Function('policy_conflict', gi.pol_sort, gi.pol_sort, BoolSort())
+    gi.register_relation("policy_conflict", policy_conflict, is_core=True)
+    policy_inconflict = Function('policy_inconflict', gi.pol_sort, gi.pol_sort, BoolSort())
+    gi.register_relation("policy_inconflict", policy_inconflict, is_core=True)
+
+
+    p0 = gi.declare_var('policy_conflict_inner', gi.pol_sort)
+    p1 = gi.declare_var('policy_conflict_outer', gi.pol_sort)
+
+    select = gi.declare_var('policy_conflict_select', gi.pod_sort)
+
+    gi.add_rule(policy_inconflict(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        is_pod(select),
+        selected_by_pol(select, p0),
+        selected_by_pol(select, p1)
+    ])
+    gi.add_rule(policy_inconflict(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        is_pod(select),
+        ingress_allow_by_pol(select, p0),
+        ingress_allow_by_pol(select, p1)
+    ])
+    gi.add_rule(policy_inconflict(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        is_pod(select),
+        egress_allow_by_pol(select, p0),
+        egress_allow_by_pol(select, p1)
+    ])
+
+    gi.add_rule(policy_conflict(p0, p1), [
+        is_pol(p0),
+        is_pol(p1),
+        p0 != p1,
+        Not(policy_inconflict(p0, p1))        
+    ])
+
+    fact = [policy_conflict(p0, p1)]
+    sat, answer = get_answer(gi.fp, fact)
+    if sat == z3.unsat:
+        return []
+    
+    return sat, parse_z3_result(answer)

--- a/kubesv/sample/__init__.py
+++ b/kubesv/sample/__init__.py
@@ -9,17 +9,3 @@ def setup_z3_printer():
     z3printer._PP.max_width = 200
     z3printer._PP.bounded = False
     z3printer._PP.max_lines = 1000000
-
-
-def parse_z3_or_and(answer: BoolRef):
-    # assume the answer is Or(And(Var0, Var1, ...), ...)
-    all_answer = set()
-    for i in range(answer.num_args()):
-        arg = answer.arg(i)
-        ans = [-1 for j in range(arg.num_args())]
-        for j in range(arg.num_args()):
-            # Var(0) == 1
-            num = arg.arg(j).arg(1)
-            ans[j] = num.as_long()
-        all_answer.add(tuple(ans))
-    return all_answer

--- a/kubesv/sample/example.py
+++ b/kubesv/sample/example.py
@@ -127,7 +127,48 @@ def paper_example():
             "role": role
         }))
 
-    def sample_policy():
+    def sample_policy0():
+        yml = """
+apiVersion: v1
+kind: NetworkPolicy
+metadata:
+  name: allow-default-nginx
+  namespace: default
+spec:
+  podSelector:
+    matchExpressions:
+        - {key: role, operator: NotIn, values: [tomcat, nginx]}
+    matchLabels:
+        env: prod
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          nonsense: default
+      podSelector:
+        matchLabels:
+          role: tomcat
+    ports:
+    - protocol: TCP
+      port: 6379
+  egress:
+  - to:
+    - podSelector:
+        matchExpressions:
+          - {key: role, operator: NotIn, values: [db, nginx]}
+      namespaceSelector:
+        matchExpressions:
+          - {key: l, operator: DoesNotExists}
+    ports:
+    - protocol: TCP
+      port: 5978
+"""
+        return PolicyAdapter(from_yaml('V1NetworkPolicy', yml))
+
+    def sample_policy1():
         yml = """
 apiVersion: v1
 kind: NetworkPolicy
@@ -166,10 +207,51 @@ spec:
 """
         return PolicyAdapter(from_yaml('V1NetworkPolicy', yml))
 
+    def sample_policy2():
+        yml = """
+apiVersion: v1
+kind: NetworkPolicy
+metadata:
+  name: allow-default-nginx
+  namespace: default
+spec:
+  podSelector:
+    matchExpressions:
+        - {key: role, operator: NotIn, values: [db, nginx]}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          nonsense: default
+      podSelector:
+        matchLabels:
+          role: db
+    ports:
+    - protocol: TCP
+      port: 6379
+  egress:
+  - to:
+    - podSelector:
+        matchExpressions:
+          - {key: role, operator: NotIn, values: [tomcat, nginx]}
+      namespaceSelector:
+        matchExpressions:
+          - {key: l, operator: DoesNotExists}
+    ports:
+    - protocol: TCP
+      port: 5978
+"""
+        return PolicyAdapter(from_yaml('V1NetworkPolicy', yml))
+
     # pprint(sample_policy().to_dict())
 
     pols = [
-        sample_policy()
+        sample_policy0(),
+        sample_policy1(),
+        sample_policy2()
     ]
     
     return pods, pols, nams    

--- a/kubesv/spec.pl
+++ b/kubesv/spec.pl
@@ -69,11 +69,13 @@ select_by_any(Pod) :-
 
 % if the traffic source is the pod's local node
 ingress_traffic(Pod, Pod).
+
 % ... OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod
 ingress_traffic(SrcPod, SelectedPod) :-
     select_by_pol(SelectedPod, Pol),
     ingress_allow_by_pol(SrcPod, Pol)
     .
+
 % ... OR there are no NetworkPolicies selecting the pod (and cluster policy otherwise [like ClusterRole] allows the traffic)
 ingress_traffic(_, SelectedPod) :-
     \(select_by_any(SelectedPod)).
@@ -83,6 +85,7 @@ egress_traffic(DstPod, SelectedPod) :-
     select_by_pol(SelectedPod, Pol),
     egress_allow_by_pol(SrcPod, Pol)
     .
+
 % ... OR there are no NetworkPolicies selecting the pod (and cluster policy otherwise [like ClusterRole] allows the traffic)
 egress_traffic(_, SelectedPod) :-
     \(select_by_any(SelectedPod)).

--- a/test.py
+++ b/test.py
@@ -1,0 +1,86 @@
+import yaml
+import kano_py.kano.algorithm as kano
+import kubesv.kubesv.postprocess as ksv
+
+from contextlib import contextmanager
+from time import perf_counter
+from kano_py.kano.model import *
+from kano_py.kano.parser import ConfigParser
+from kano_py.tests.generate import ConfigFiles
+from kubesv.kubesv.constraint import *
+from kubesv.kubesv.postprocess import *
+from kubesv.kubesv.parser import from_yaml
+
+
+@contextmanager
+def timing(description: str) -> None:
+    start = perf_counter()
+    yield
+    ellapsed_time = perf_counter() - start
+
+    print(f"{description}: {ellapsed_time}")
+
+
+def read_kubesv_yaml(filepath):
+    pods = []
+    policies = []
+    for subdir, _, files in os.walk(filepath):
+        for file in files:
+            filename = os.path.join(subdir, file)
+            with open(filename, 'r') as f:
+                if file.startswith("pod"):
+                    pods.append(PodAdapter(from_yaml('V1Pod', f)))
+                elif file.startswith('policy'):
+                    policies.append(PolicyAdapter(from_yaml('V1NetworkPolicy', f)))
+
+    ns_templ = """
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: default
+"""
+    default_namespace = NamespaceAdapter(from_yaml('V1Namespace', ns_templ))
+
+    return pods, policies, [default_namespace]
+
+
+def compare_results():
+    config = ConfigFiles()
+    config.generateConfigFiles()
+    cp = ConfigParser()
+    containers, policies = cp.parse('./data')
+
+    with timing("calculating reachability matrix"):
+        matrix = ReachabilityMatrix.build_matrix(containers, policies)
+
+    # https://github.com/Z3Prover/z3/discussions/4992
+    # @nunoplopes: If you really need speed, you can't use Python. Python is slow and Z3's Python API is super slow.
+    with timing("calculating SMT constraints"):
+        k_pods, k_pols, k_ns = read_kubesv_yaml('./data')
+        gi = build(k_pods, k_pols, k_ns, 
+                check_self_ingress_traffic=False, 
+                check_select_by_no_policy=False)
+    
+    with timing("measuring kano algorithm speed"):
+        kano_results = {
+            "algorithm": "kano",
+            "all_reachable": kano.all_reachable(matrix),
+            "all_isolated": kano.all_isolated(matrix),
+            "user_crosscheck": kano.user_crosscheck(matrix, containers, "User"),
+        }
+
+    with timing("measuring z3 algorithm speed"):
+        ar, ai = ksv.all_reach_isolate(gi)
+        ksv_results = {
+            "algorithm": "z3nd",
+            "all_reachable": ar,
+            "all_isolated": ai,
+            "user_crosscheck": list(ksv.user_crosscheck(gi, "User")[1]),
+        }
+
+    print(kano_results)
+    print(ksv_results)
+
+
+if __name__ == "__main__":
+    compare_results()

--- a/test.py
+++ b/test.py
@@ -45,10 +45,11 @@ metadata:
 
 
 def compare_results():
-    config = ConfigFiles()
+    config = ConfigFiles(podN=100)
     config.generateConfigFiles()
     cp = ConfigParser()
     containers, policies = cp.parse('./data')
+    k_pods, k_pols, k_ns = read_kubesv_yaml('./data')
 
     with timing("calculating reachability matrix"):
         matrix = ReachabilityMatrix.build_matrix(containers, policies)
@@ -56,7 +57,6 @@ def compare_results():
     # https://github.com/Z3Prover/z3/discussions/4992
     # @nunoplopes: If you really need speed, you can't use Python. Python is slow and Z3's Python API is super slow.
     with timing("calculating SMT constraints"):
-        k_pods, k_pols, k_ns = read_kubesv_yaml('./data')
         gi = build(k_pods, k_pols, k_ns, 
                 check_self_ingress_traffic=False, 
                 check_select_by_no_policy=False)
@@ -78,8 +78,8 @@ def compare_results():
             "user_crosscheck": list(ksv.user_crosscheck(gi, "User")[1]),
         }
 
-    print(kano_results)
-    print(ksv_results)
+    # print(kano_results)
+    # print(ksv_results)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Equivalent algorithm: `all_reachable`, `all_isolation`, `user_crosscheck`, `system_isolation` (can't be tested without a idx).
For `policy_shadow` and `policy_conflict`, we can define the more intuitive version (not per pod but actually covered)

AFAIC, the results from two implementations are the same for equivalent algorithms.

Sad news: SMT constraint generations are 40x slower reachable matrix generation, algorithm solving is 10x slower than ad hoc algorithm.

Given python z3 API is super slow and Kano doesn't actually implement a valid k8s verifier, the results seem to be less meaningful.