### PR TITLE
Kano and z3 optimizations

### DIFF
--- a/kano_py/kano/algorithm.py
+++ b/kano_py/kano/algorithm.py
@@ -2,18 +2,18 @@ from .model import *
 
 
 def all_reachable(matrix: ReachabilityMatrix) -> List[int]:
-    all_reachables = []
+    all_reachables = set()
     for i in range(matrix.container_size):
         if matrix.getcol(i).count() == matrix.container_size:
-            all_reachables.append(i)
+            all_reachables.add(i)
     return all_reachables
 
 
 def all_isolated(matrix: ReachabilityMatrix) -> List[int]:
-    all_isolated = []
+    all_isolated = set()
     for i in range(matrix.container_size):
         if matrix.getcol(i).count() == 0:
-            all_isolated.append(i)
+            all_isolated.add(i)
     return all_isolated
 
 
@@ -32,13 +32,13 @@ def user_crosscheck(
     User cross. 
     A container can be reached from other user’s container in the container network
     """
-    user_crosslist = []
+    user_crosslist = set()
     user_map = user_hashmap(containers, label)
     for i, container in enumerate(containers):
         diff_set = ~ user_map[container.getValueOrDefault(label, "")]
         diff_set &= matrix.getcol(i)
         if diff_set.count() != 0:
-            user_crosslist.append(i)
+            user_crosslist.add(i)
     return user_crosslist
 
 

--- a/kano_py/kano/model.py
+++ b/kano_py/kano/model.py
@@ -28,11 +28,15 @@ class Container:
 @dataclass
 class PolicySelect:
     labels: Dict[str, str]
+    is_allow_all = False
+    is_deny_all = False
 
 
 @dataclass
 class PolicyAllow:
     labels: Dict[str, str]
+    is_allow_all = False
+    is_deny_all = False
 
 
 @dataclass
@@ -162,6 +166,16 @@ class ReachabilityMatrix:
                     allow_set[idx] = False
             
             policy.store_bcp(select_set, allow_set)
+
+            if policy.working_allow.is_allow_all:
+                allow_set.setall(True)
+            elif policy.working_allow.is_deny_all:
+                allow_set.setall(False)
+            
+            if policy.working_selector.is_allow_all:
+                select_set.setall(True)
+            elif policy.working_selector.is_deny_all:
+                select_set.setall(False)            
 
             for idx in range(n_container):
                 if allow_set[idx]:

--- a/kano_py/tests/generate.py
+++ b/kano_py/tests/generate.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from ..kano.model import *
 
 class ConfigFiles:
-    def __init__(self, podN=100,nsN=5,policyN=50,podLL=5,nsLL=5,keyL=5,valueL=10,userL=5,selectedLL=3,allowNSLL=3,allowpodLL=3):
+    def __init__(self, directory='data', podN=100,nsN=5,policyN=50,podLL=5,nsLL=5,keyL=5,valueL=10,userL=5,selectedLL=3,allowNSLL=3,allowpodLL=3):
         self.podN = podN
         self.nsN = nsN
         self.policyN = policyN
@@ -18,9 +18,9 @@ class ConfigFiles:
         self.selectedLL = selectedLL
         self.allowNSLL = allowNSLL
         self.allowpodLL = allowpodLL
-        self.directory = "data/policy"
-        if not os.path.exists("data"):
-            os.makedirs("data")
+        self.directory = directory
+        if not os.path.exists(directory):
+            os.makedirs(directory)
         self.generatePods()
         # self.generateNamespaces()
 
@@ -44,7 +44,7 @@ class ConfigFiles:
                 'namespace': 'default',
                 'labels': labels
             }
-            with open("data/pod{}.yml".format(i), 'w+') as f:
+            with open("{}/pod{}.yml".format(self.directory, i), 'w+') as f:
                 f.write(yaml.dump(y_pod, default_flow_style=False, sort_keys=False))
 
         self.containers = containers
@@ -89,7 +89,7 @@ class ConfigFiles:
 
             # write to config file
             #f = open(self.directory + str(i) + ".yml", "a")
-            f = open(self.directory + str(i) + ".yml", "w")
+            f = open(self.directory + "/policy" + str(i) + ".yml", "w")
             f.write(data)
             f.close()
         return

--- a/kubesv/kubesv/utils.py
+++ b/kubesv/kubesv/utils.py
@@ -1,0 +1,52 @@
+from z3 import *
+from typing import *
+from typing_extensions import *
+
+
+def parse_z3_var_assignment(assign):
+    idx = get_var_index(assign.arg(0))
+    num = assign.arg(1).as_long()
+    return idx, num
+
+
+def parse_z3_and_var(assigns):
+    results = []
+    for i in range(assigns.num_args()):
+        assign = assigns.arg(i)
+        results.append(parse_z3_var_assignment(assign))
+    return results
+
+
+def parse_z3_or_and(answer: BoolRef) -> Set[Tuple[int, ...]]:
+    # assume the answer is Or(And(Var0, Var1, ...), ...)
+    all_answer = None
+    
+    if is_eq(answer):
+        return parse_z3_var_assignment(answer)
+
+    if is_and(answer):
+        all_answer = [-1 for _ in range(answer.num_args())]
+        for i in range(answer.num_args()):
+            assign = answer.arg(i)
+            idx, num = parse_z3_or_and(assign)
+            all_answer[idx] = num
+    elif is_or(answer):
+        all_answer = set()
+        for i in range(answer.num_args()):
+            assigns = answer.arg(i)
+            result = parse_z3_or_and(assigns)
+            if isinstance(result, tuple):
+                all_answer.add(result[1])
+            else:
+                all_answer.add(tuple(result))
+
+    return all_answer
+
+
+def parse_z3_result(answer: BoolRef):
+    result = parse_z3_or_and(answer)
+    if isinstance(result, list):
+        return {tuple(result)}
+    elif isinstance(result, tuple):
+        return {result[1]}
+    return result

--- a/kubesv/tests/test_basic.py
+++ b/kubesv/tests/test_basic.py
@@ -1,3 +1,4 @@
+from kubesv.kubesv.constraint import ground_default_pods
 from kubesv.constraint import *
 from kubesv.postprocess import *
 from .context import sample
@@ -15,7 +16,8 @@ class BasicTestSuite(unittest.TestCase):
         pods, pols, nams = sample.paper_example()
         gi = build(pods, pols, nams, 
             check_self_ingress_traffic=False, 
-            check_select_by_no_policy=False)
+            check_select_by_no_policy=False,
+            ground_default_pod=False)
 
         rch, iso = all_reach_isolate(gi)
         print(rch)


### PR DESCRIPTION
1. Add allow-all option for Kano: Kano is modeling k8s correctly now except NS.
2. Add ground default pod option for z3: do a extra round to add all default pods to avoid negation.
3. Optimize the slow fetching process used in reachable pair matching: now the all_reachable/isolated results are directly computed in z3.

Now for pod ~10k, the z3 algorithm is faster again(?).
As z3 computes in C++ and Kano computes in Python, we don't know if the results are meaningful :(